### PR TITLE
Patch/site url

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,6 +5,7 @@ import { defineConfig } from "astro/config";
 
 // https://astro.build/config
 export default defineConfig({
-  site: "https://example.com",
+  site: "https://cmdecker95.github.io",
+  base: "/blog",
   integrations: [mdx(), sitemap()],
 });

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,7 +5,7 @@ import { defineConfig } from "astro/config";
 
 // https://astro.build/config
 export default defineConfig({
-  site: "https://cmdecker95.github.io",
-  base: "/blog",
+  site: "https://cmdecker95.github.io/blog",
+  base: "/",
   integrations: [mdx(), sitemap()],
 });


### PR DESCRIPTION
This pull request includes a change to the `astro.config.mjs` file to update the site URL and add a base path.

Configuration updates:

* [`astro.config.mjs`](diffhunk://#diff-e0f0c5adbe0b9ca5d0b57caf5cea33a8d88899fd02a43df1e9862b185f8a1e5fL8-R9): Updated the `site` URL to "https://cmdecker95.github.io/blog" and added a `base` path set to "/".